### PR TITLE
fix: CI環境でのsemantic-releaseリリース失敗を修正

### DIFF
--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -11,26 +11,39 @@ permissions:
   id-token: write
 
 jobs:
-  preview:
+  verify-npm-token:
+    name: Verify npm token
     runs-on: ubuntu-latest
+    outputs:
+      valid: ${{ steps.check.outputs.valid }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '22.x'
           registry-url: 'https://registry.npmjs.org'
 
-      - name: Verify npm token
-        id: npm_token
-        continue-on-error: true
-        run: npm whoami --registry https://registry.npmjs.org/ >/dev/null 2>&1 && echo "valid=true" >> "$GITHUB_OUTPUT" || echo "valid=false" >> "$GITHUB_OUTPUT"
+      - name: Check npm token
+        id: check
+        run: |
+          if npm whoami --registry https://registry.npmjs.org/ >/dev/null 2>&1; then
+            echo "valid=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::error::NPMトークンが無効または期限切れです。リポジトリのSecretsでNPM_TOKENを更新してください。"
+            exit 1
+          fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  preview:
+    needs: verify-npm-token
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       # semantic-releaseのdry-runはPRブランチ上では動作しないため、
       # コミットメッセージを直接解析してバージョンを算出する。
@@ -87,7 +100,7 @@ jobs:
             const hasRelease = '${{ steps.analyze.outputs.has_release }}' === 'true';
             const current = '${{ steps.analyze.outputs.current_version }}';
             const next = '${{ steps.analyze.outputs.next_version }}';
-            const npmTokenValid = '${{ steps.npm_token.outputs.valid }}' === 'true';
+            const npmTokenValid = '${{ needs.verify-npm-token.outputs.valid }}' === 'true';
 
             const version = hasRelease
               ? `v${current} → **v${next}**`

--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  id-token: write
 
 jobs:
   preview:
@@ -17,6 +18,19 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.x'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Verify npm token
+        id: npm_token
+        continue-on-error: true
+        run: npm whoami --registry https://registry.npmjs.org/ >/dev/null 2>&1 && echo "valid=true" >> "$GITHUB_OUTPUT" || echo "valid=false" >> "$GITHUB_OUTPUT"
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       # semantic-releaseのdry-runはPRブランチ上では動作しないため、
       # コミットメッセージを直接解析してバージョンを算出する。
@@ -73,10 +87,22 @@ jobs:
             const hasRelease = '${{ steps.analyze.outputs.has_release }}' === 'true';
             const current = '${{ steps.analyze.outputs.current_version }}';
             const next = '${{ steps.analyze.outputs.next_version }}';
+            const npmTokenValid = '${{ steps.npm_token.outputs.valid }}' === 'true';
 
-            const body = hasRelease
-              ? `### リリースプレビュー\n\n**v${current}** → **v${next}**`
-              : `### リリースプレビュー\n\nリリース対象のコミットなし（v${current}のまま）`;
+            const version = hasRelease
+              ? `v${current} → **v${next}**`
+              : `v${current}（変更なし）`;
+            const npmStatus = npmTokenValid ? '有効 ✅' : '無効 ❌';
+
+            let body = `### リリースプレビュー\n\n`;
+            body += `| 項目 | 状態 |\n`;
+            body += `| --- | --- |\n`;
+            body += `| バージョン | ${version} |\n`;
+            body += `| NPMトークン | ${npmStatus} |\n`;
+
+            if (!npmTokenValid) {
+              body += `\n> [!CAUTION]\n> NPMトークンが無効または期限切れです。マージ前にリポジトリのSecretsで \`NPM_TOKEN\` を更新してください。`;
+            }
 
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,8 @@ jobs:
     - run: npm ci
     - run: npm test
 
-  test-on-volta:
+  cli-install:
+    name: CLI install
     runs-on: ubuntu-latest
 
     strategy:
@@ -33,25 +34,21 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - uses: volta-cli/action@v1
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
 
-    - run: node -v
-    - uses: actions/checkout@v4
-
-    - name: install yukichant on local
+    - name: Global install
       run: |
         npm install
-        npm install -g ../yukichant
+        npm install -g .
 
-    - name: mkdir sandbox
-      run: mkdir -p ./exec_dir
-
-    - name: check cli path
+    - name: Verify CLI is available
       run: which chant
-      working-directory: ./exec_dir
+      working-directory: /tmp
 
-    - run: chant
-      working-directory: ./exec_dir
+    - name: Run CLI
+      run: chant
+      working-directory: /tmp
 

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,1 +1,2 @@
+[ "$CI" = "true" ] && exit 0
 npx --no -- commitlint --edit $1


### PR DESCRIPTION
## 概要

semantic-releaseによる自動リリースがCI環境で失敗する2つの問題を修正します。

- **commitlintフックのスキップ**: `@semantic-release/git` のコミットメッセージ（`[release] x.x.x`）がConventional Commits形式でないため、huskyのcommit-msgフックに拒否されていた。CI環境（`CI=true`）ではフックをスキップするように修正
- **NPMトークン検証の追加**: リリースプレビュー時に`NPM_TOKEN`の有効性を事前検証し、PRコメントに結果を表示。トークン切れによるマージ後のリリース失敗を未然に防止

## 変更内容

### `.husky/commit-msg`
- `CI=true` の場合にcommitlintをスキップする処理を追加

### `.github/workflows/release-preview.yml`
- `npm whoami` によるNPMトークン検証ステップを追加
- PRコメントにトークンの状態を表示（有効: NOTE / 無効: CAUTION）

## テスト計画

- [x] PRを作成してrelease-previewワークフローが正常に動作することを確認
- [x] PRコメントにNPMトークンの状態が表示されることを確認
- [ ] masterにマージしてsemantic-releaseが正常にリリースできることを確認