### PR TITLE
ci: npm Trusted Publishingに移行

### DIFF
--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -8,36 +8,9 @@ on:
 permissions:
   contents: read
   pull-requests: write
-  id-token: write
 
 jobs:
-  verify-npm-token:
-    name: Verify npm token
-    runs-on: ubuntu-latest
-    outputs:
-      valid: ${{ steps.check.outputs.valid }}
-    steps:
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '22.x'
-          registry-url: 'https://registry.npmjs.org'
-
-      - name: Check npm token
-        id: check
-        run: |
-          if npm whoami --registry https://registry.npmjs.org/ >/dev/null 2>&1; then
-            echo "valid=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "::error::NPMトークンが無効または期限切れです。リポジトリのSecretsでNPM_TOKENを更新してください。"
-            exit 1
-          fi
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
   preview:
-    needs: verify-npm-token
-    if: always()
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -100,22 +73,15 @@ jobs:
             const hasRelease = '${{ steps.analyze.outputs.has_release }}' === 'true';
             const current = '${{ steps.analyze.outputs.current_version }}';
             const next = '${{ steps.analyze.outputs.next_version }}';
-            const npmTokenValid = '${{ needs.verify-npm-token.outputs.valid }}' === 'true';
 
             const version = hasRelease
               ? `v${current} → **v${next}**`
               : `v${current}（変更なし）`;
-            const npmStatus = npmTokenValid ? '有効 ✅' : '無効 ❌';
 
             let body = `### リリースプレビュー\n\n`;
             body += `| 項目 | 状態 |\n`;
             body += `| --- | --- |\n`;
             body += `| バージョン | ${version} |\n`;
-            body += `| NPMトークン | ${npmStatus} |\n`;
-
-            if (!npmTokenValid) {
-              body += `\n> [!CAUTION]\n> NPMトークンが無効または期限切れです。マージ前にリポジトリのSecretsで \`NPM_TOKEN\` を更新してください。`;
-            }
 
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,9 @@ jobs:
           node-version: '22.x'
           registry-url: 'https://registry.npmjs.org'
 
+      - name: Update npm for trusted publishing
+        run: npm install -g npm@latest
+
       - name: Install dependencies
         run: npm ci
 
@@ -34,4 +37,4 @@ jobs:
         run: npx semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true

--- a/package.json
+++ b/package.json
@@ -3,7 +3,10 @@
   "version": "3.1.0-beta.11",
   "description": "",
   "license": "Apache-2.0",
-  "repository": "amanoese/yukichant",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/amanoese/yukichant.git"
+  },
   "author": "Seito Taka",
   "main": "src/node.js",
   "exports": {


### PR DESCRIPTION
## 概要

npm公開の認証方式を長期トークン（`NPM_TOKEN`）からOIDCベースのTrusted Publishingに移行します。

- 長期トークンの管理が不要になり、トークン期限切れによるリリース失敗を防止
- OIDCによる短期トークンの自動発行でセキュリティを向上
- provenance attestation生成により、パッケージの出所を暗号的に証明

## 変更内容

### `release.yml`
- `NPM_TOKEN` シークレットの参照を削除
- `npm install -g npm@latest` を追加（Trusted PublishingはCLI v11.5.1以上が必要）
- `NPM_CONFIG_PROVENANCE: true` を追加

### `release-preview.yml`
- `verify-npm-token` ジョブを削除（トークン検証が不要に）
- PRコメントからNPMトークンの状態表示を削除

### `package.json`
- `repository` フィールドをオブジェクト形式に変更（Trusted Publishingのリポジトリ照合に必要）

## マージ前の準備

- [x] npmjs.comで [yukichantのアクセス設定](https://www.npmjs.com/package/yukichant/access) を開き、Trusted Publisherを設定する
  - Repository owner: `amanoese`
  - Repository name: `yukichant`
  - Workflow filename: `release.yml`

## マージ後の作業

- [ ] リポジトリのSecretsから `NPM_TOKEN` を削除

Made with [Cursor](https://cursor.com)