### PR TITLE
fix: BREAKING CHANGEがmajorリリースになるよう修正

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -4,6 +4,7 @@
     ["@semantic-release/commit-analyzer", {
       "preset": "conventionalcommits",
       "releaseRules": [
+        { "breaking": true, "release": "major" },
         { "type": "feat", "release": "minor" },
         { "type": "fix", "release": "patch" },
         { "type": "perf", "release": "patch" },

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -14,6 +14,7 @@ export default {
       'deps',
       'release',
     ]],
+    'subject-case': [0],
     'subject-empty': [2, 'never'],
     'type-empty': [2, 'never'],
   },


### PR DESCRIPTION
## Summary

- `.releaserc.json`の`releaseRules`に`{ "breaking": true, "release": "major" }`を追加
- `commitlint.config.js`の`subject-case`ルールを無効化（日本語や技術用語の大文字を許容）

## 背景

`feat!:`や`BREAKING CHANGE`フッター付きコミットが`minor`として扱われ、v3.1.0でリリースされてしまった問題の修正です。

このPRのマージ後、既存の`feat!:`コミットが正しく`major`と判定され、semantic-releaseがv4.0.0を生成します。

## 実施済みの作業

- [x] git tag `v3.1.0` の削除
- [x] GitHub Release `v3.1.0` の削除
- [x] npm `yukichant@3.1.0` の unpublish


Made with [Cursor](https://cursor.com)