### PR TITLE
fix: GitHub Pages上で辞書ファイルのURL解決を修正

### DIFF
--- a/demo/path-shim.js
+++ b/demo/path-shim.js
@@ -1,0 +1,18 @@
+import pathBrowserify from 'path-browserify'
+
+const originalJoin = pathBrowserify.join.bind(pathBrowserify)
+
+pathBrowserify.join = function (...args) {
+  if (args.length > 0 && /^https?:\/\//.test(args[0])) {
+    const base = args[0].replace(/\/+$/, '')
+    const rest = args.slice(1).map(s => s.replace(/^\/+|\/+$/g, ''))
+    return [base, ...rest].join('/')
+  }
+  return originalJoin(...args)
+}
+
+export default pathBrowserify
+export const {
+  resolve, normalize, isAbsolute, join, relative,
+  dirname, basename, extname, format, parse, sep, delimiter, posix, win32,
+} = pathBrowserify

--- a/demo/vite.config.js
+++ b/demo/vite.config.js
@@ -7,7 +7,7 @@ export default defineConfig({
   plugins: [vue()],
   resolve: {
     alias: {
-      path: resolve('node_modules/path-browserify'),
+      path: resolve('path-shim.js'),
     },
   },
   build: {


### PR DESCRIPTION
## Summary
- GitHub Pages上でkuromojiの辞書ファイルのURLが正しく解決されない問題を修正
- `path-browserify`の`join`が`https://`プロトコルを壊すため、URL対応のpath shimを作成

## 原因
`path-browserify`の`path.join('https://raw.githubusercontent.com/.../dic/', 'base.dat.gz')`が`https:/raw.githubusercontent.com/.../dic/base.dat.gz`を返し、ブラウザが相対URLとして`https://amanoese.github.io/raw.githubusercontent.com/...`に解決していた

## 修正内容
- `demo/path-shim.js`: `path.join`の第1引数がHTTP(S) URLの場合、スラッシュを保持して結合するshimを作成
- `demo/vite.config.js`: `path`エイリアスをpath-shimに変更

## Test plan
- [x] ビルド成功
- [x] path shimのURL結合テスト通過
- [ ] デプロイ後に https://amanoese.github.io/yukichant/ で辞書読み込み成功を確認

Made with [Cursor](https://cursor.com)