### PR TITLE
fix: Node環境で辞書パス解決を安定化

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -1,5 +1,6 @@
 import fs from 'fs'
 import path from 'path'
+import { createRequire } from 'node:module'
 import kuromoji from 'kuromoji'
 import natural from 'natural'
 import typoCorrection from './typo-correction.js'
@@ -7,16 +8,26 @@ import { initTypoCorrection } from './typo-correction.js'
 import fkm, { initFuzzyKanjiMatch } from './fuzzy-kanji-match.js'
 import { createChant } from './index.js'
 
-const dirname = path.dirname(new URL(import.meta.url).pathname)
-const meisi = JSON.parse(fs.readFileSync(`${dirname}/../data/meisi.json`, 'utf8'));
-const dousi = JSON.parse(fs.readFileSync(`${dirname}/../data/dousi.json`, 'utf8'));
-const kanji2element = JSON.parse(fs.readFileSync(`${dirname}/../node_modules/kanjivg-radical/data/kanji2radical.json`, 'utf8'));
+const require = createRequire(import.meta.url)
+
+const meisi = JSON.parse(fs.readFileSync(new URL('../data/meisi.json', import.meta.url), 'utf8'));
+const dousi = JSON.parse(fs.readFileSync(new URL('../data/dousi.json', import.meta.url), 'utf8'));
+
+const kanji2radicalPath = require.resolve('kanjivg-radical/data/kanji2radical.json')
+const kanjiVgRadicalDir = path.dirname(path.dirname(kanji2radicalPath))
+const kanji2element = JSON.parse(
+  fs.readFileSync(path.join(kanjiVgRadicalDir, 'data', 'kanji2radical.json'), 'utf8')
+);
+
+const yukidicBasePath = require.resolve('yukidic/dic/base.dat.gz')
+const yukidicDir = path.dirname(path.dirname(yukidicBasePath))
+const dicPath = path.join(yukidicDir, 'dic') + path.sep
 
 initFuzzyKanjiMatch({ meisi, dousi, kanji2element, TfIdf: natural.TfIdf });
 
 const tokenizer = await new Promise((resolve, reject) => {
   kuromoji
-    .builder({ dicPath: `${dirname}/../node_modules/yukidic/dic/` })
+    .builder({ dicPath })
     .build(function (err, tokenizer) {
       if (err != null) {
         reject(err);


### PR DESCRIPTION
## Summary
- `src/node.js` で `createRequire` を使い、依存パッケージ配下の辞書パスを `require.resolve` ベースで解決するように変更
- `yukidic` の辞書パスを固定の `node_modules` 相対参照から動的解決に置き換え、実行環境差異による読み込み失敗を回避
- `kanjivg-radical` の JSON 読み込みも同様にモジュール解決へ統一

## Test plan
- [ ] `npm test`
- [ ] `npm run dev unko`
- [ ] `echo "破滅を御前に意に従い借り。" | npm run dev -- -d`

Made with [Cursor](https://cursor.com)