### PR TITLE
release: develop の変更を master に反映

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -1,5 +1,6 @@
 import fs from 'fs'
 import path from 'path'
+import { createRequire } from 'node:module'
 import kuromoji from 'kuromoji'
 import natural from 'natural'
 import typoCorrection from './typo-correction.js'
@@ -7,16 +8,26 @@ import { initTypoCorrection } from './typo-correction.js'
 import fkm, { initFuzzyKanjiMatch } from './fuzzy-kanji-match.js'
 import { createChant } from './index.js'
 
-const dirname = path.dirname(new URL(import.meta.url).pathname)
-const meisi = JSON.parse(fs.readFileSync(`${dirname}/../data/meisi.json`, 'utf8'));
-const dousi = JSON.parse(fs.readFileSync(`${dirname}/../data/dousi.json`, 'utf8'));
-const kanji2element = JSON.parse(fs.readFileSync(`${dirname}/../node_modules/kanjivg-radical/data/kanji2radical.json`, 'utf8'));
+const require = createRequire(import.meta.url)
+
+const meisi = JSON.parse(fs.readFileSync(new URL('../data/meisi.json', import.meta.url), 'utf8'));
+const dousi = JSON.parse(fs.readFileSync(new URL('../data/dousi.json', import.meta.url), 'utf8'));
+
+const kanji2radicalPath = require.resolve('kanjivg-radical/data/kanji2radical.json')
+const kanjiVgRadicalDir = path.dirname(path.dirname(kanji2radicalPath))
+const kanji2element = JSON.parse(
+  fs.readFileSync(path.join(kanjiVgRadicalDir, 'data', 'kanji2radical.json'), 'utf8')
+);
+
+const yukidicBasePath = require.resolve('yukidic/dic/base.dat.gz')
+const yukidicDir = path.dirname(path.dirname(yukidicBasePath))
+const dicPath = path.join(yukidicDir, 'dic') + path.sep
 
 initFuzzyKanjiMatch({ meisi, dousi, kanji2element, TfIdf: natural.TfIdf });
 
 const tokenizer = await new Promise((resolve, reject) => {
   kuromoji
-    .builder({ dicPath: `${dirname}/../node_modules/yukidic/dic/` })
+    .builder({ dicPath })
     .build(function (err, tokenizer) {
       if (err != null) {
         reject(err);


### PR DESCRIPTION
## Summary
- `develop` に取り込まれた `feature/resolve-module-dic-paths` の変更を `master` に反映します
- `src/node.js` の辞書ファイル解決を `require.resolve` ベースへ統一し、実行環境差異によるパス解決失敗を回避します
- リリースブランチ運用に沿って、`develop` 集約済み変更を本番系ブランチへ昇格します

## Test plan
- [ ] CI（test workflow）が成功することを確認
- [ ] `npm test` が成功することを確認
- [ ] エンコード/デコードの基本動作を手元で確認（`npm run dev unko` / `npm run dev -- -d`）

Made with [Cursor](https://cursor.com)